### PR TITLE
Add framework for sub-command grouping to keep things organized

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,4 +40,4 @@ changelog:
 release:
   prerelease: auto
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       - windows
       - darwin
     ldflags:
-      - -X github.com/mallardduck/ob-charts-tool/cmd.Version={{.Version}} -X github.com/mallardduck/ob-charts-tool/cmd.GitCommit={{.ShortCommit}}
+      - -X github.com/rancher/ob-charts-tool/cmd.Version={{.Version}} -X github.com/rancher/ob-charts-tool/cmd.GitCommit={{.ShortCommit}}
 
 archives:
   - format: binary

--- a/cmd/getRebaseInfo.go
+++ b/cmd/getRebaseInfo.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/mallardduck/ob-charts-tool/internal/cmd/rebaseinfo"
+	"github.com/rancher/ob-charts-tool/internal/cmd/rebaseinfo"
 
 	"github.com/jedib0t/go-pretty/text"
 	"github.com/spf13/cobra"

--- a/cmd/groups/groups.go
+++ b/cmd/groups/groups.go
@@ -1,0 +1,13 @@
+package groups
+
+import "github.com/spf13/cobra"
+
+var MonitoringGroup cobra.Group = cobra.Group{
+	ID:    "monitoring",
+	Title: "Monitoring Commands:",
+}
+
+var LoggingGroup cobra.Group = cobra.Group{
+	ID:    "logging",
+	Title: "Logging Commands:",
+}

--- a/cmd/monitoring/getRebaseInfo.go
+++ b/cmd/monitoring/getRebaseInfo.go
@@ -1,21 +1,22 @@
-package cmd
+package monitoring
 
 import (
 	"fmt"
 	"os"
 
-	log "github.com/sirupsen/logrus"
-
-	"github.com/rancher/ob-charts-tool/internal/cmd/rebaseinfo"
-
 	"github.com/jedib0t/go-pretty/text"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/rancher/ob-charts-tool/cmd/groups"
+	"github.com/rancher/ob-charts-tool/internal/cmd/rebaseinfo"
 )
 
 // getRebaseInfoCmd represents the getRebaseInfo command
 var getRebaseInfoCmd = &cobra.Command{
-	Use:   "getRebaseInfo",
-	Short: "Collect the basic information about a potential rebase target version",
+	Use:     "getRebaseInfo",
+	Short:   "Collect the basic information about a potential rebase target version",
+	GroupID: groups.MonitoringGroup.ID,
 	Args: func(_ *cobra.Command, args []string) error {
 		// Check if there's one argument provided
 		if len(args) == 1 {
@@ -25,10 +26,6 @@ var getRebaseInfoCmd = &cobra.Command{
 		return fmt.Errorf("you must provide the target upstream chart version")
 	},
 	Run: getRebaseInfoHandler,
-}
-
-func init() {
-	rootCmd.AddCommand(getRebaseInfoCmd)
 }
 
 func getRebaseInfoHandler(_ *cobra.Command, args []string) {

--- a/cmd/monitoring/monitoring.go
+++ b/cmd/monitoring/monitoring.go
@@ -1,0 +1,25 @@
+package monitoring
+
+import (
+	"fmt"
+	"github.com/rancher/ob-charts-tool/cmd/groups"
+	"github.com/spf13/cobra"
+)
+
+func subCommandList() []*cobra.Command {
+	return []*cobra.Command{
+		getRebaseInfoCmd,
+	}
+}
+
+func init() {
+	for _, cmd := range subCommandList() {
+		cmd.Use = fmt.Sprintf("%s:%s", groups.MonitoringGroup.ID, cmd.Use)
+	}
+}
+
+func RegisterMonitoringSubcommands(cmd *cobra.Command) {
+	for _, subCmd := range subCommandList() {
+		cmd.AddCommand(subCmd)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,14 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"strings"
-
-	log "github.com/sirupsen/logrus"
+	"github.com/mallardduck/ob-charts-tool/internal/logging"
 	"github.com/spf13/viper"
+	"os"
 
 	"github.com/spf13/cobra"
 )
+
+const cliName = "ob-charts-tool"
 
 var (
 	// Version represents the current version of the chart build scripts
@@ -18,9 +18,13 @@ var (
 	GitCommit = "HEAD"
 )
 
+var (
+	cfgFile string
+)
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "ob-charts-tool",
+	Use:   cliName,
 	Short: "A brief description of your application",
 	Long: `A longer description that spans multiple lines and likely contains
 examples and usage of using your application. For example:
@@ -29,45 +33,68 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Version: fmt.Sprintf("v%s (%s)", Version, GitCommit),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// This function runs before any command's Run, RunE, PreRun, or PreRunE.
+		// It's the ideal place to initialize Viper and set up logging.
+		initConfig()
+		logging.Configure(cmd) // Now configures Logrus (via logging internal pkg)
+		return nil
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	logLevel := viper.GetString("log_level")
-	if logLevel == "" {
-		logLevel = "warn"
-	}
-
-	// Set up logging based on logLevel
-	switch strings.ToLower(logLevel) {
-	case "debug":
-		log.SetOutput(os.Stderr)
-		log.SetLevel(log.DebugLevel)
-	case "info":
-		log.SetOutput(os.Stderr)
-		log.SetLevel(log.InfoLevel)
-	case "warn":
-		log.SetOutput(os.Stderr)
-		log.SetLevel(log.WarnLevel)
-	case "error":
-		log.SetOutput(os.Stderr)
-		log.SetLevel(log.ErrorLevel)
-	default:
-		log.Println("Invalid log level")
-	}
-
-	err := rootCmd.Execute()
-	if err != nil {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 }
 
 func init() {
+	cobra.OnInitialize(initConfig)
+
+	// Setup log-level global flag
+	rootCmd.PersistentFlags().StringP("log-level", "l", "info", "Set the logging level (debug, info, warn, error, fatal, panic)")
+
+	// Viper config
 	viper.SetEnvPrefix("OB")
 	viper.AutomaticEnv()
-	err := viper.BindEnv("log_level")
+	err := viper.BindEnv("log_level", "OB_LOG_LEVEL")
 	if err != nil {
+		logging.Log.Error(err)
 		return
+	}
+
+	// Bind the log-level flag to Viper (this also makes it available via viper.GetString)
+	err = viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
+	if err != nil {
+		logging.Log.Error(err)
+		return
+	}
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		// Search config in home directory with name ".mycli" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigName("." + cliName)
+	}
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		_, err = fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		if err != nil {
+			logging.Log.Error(err)
+			return
+		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/mallardduck/ob-charts-tool/internal/logging"
+	"github.com/rancher/ob-charts-tool/internal/logging"
 	"github.com/spf13/viper"
 	"os"
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,13 +25,14 @@ var (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   cliName,
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
+	Short: "A tool for working with `ob-team-charts`",
+	Long: `A CLI tool for working with the 'ob-team-charts' Helm chart repo.
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+Supports one-off tasks like inspecting chart contents (e.g., listing used images),
+as well as automating chart maintenance workflows such as rebases.
+
+Commands are either root-level (operating on multiple charts) or grouped
+under a domain prefix (e.g., 'logging:', 'monitoring:') for chart-specific actions.`,
 	Version: fmt.Sprintf("v%s (%s)", Version, GitCommit),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// This function runs before any command's Run, RunE, PreRun, or PreRunE.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/rancher/ob-charts-tool/cmd/groups"
+	"github.com/rancher/ob-charts-tool/cmd/monitoring"
 	"github.com/rancher/ob-charts-tool/internal/logging"
 	"github.com/spf13/viper"
 	"os"
@@ -35,10 +37,8 @@ Commands are either root-level (operating on multiple charts) or grouped
 under a domain prefix (e.g., 'logging:', 'monitoring:') for chart-specific actions.`,
 	Version: fmt.Sprintf("v%s (%s)", Version, GitCommit),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// This function runs before any command's Run, RunE, PreRun, or PreRunE.
-		// It's the ideal place to initialize Viper and set up logging.
 		initConfig()
-		logging.Configure(cmd) // Now configures Logrus (via logging internal pkg)
+		logging.Configure(cmd)
 		return nil
 	},
 }
@@ -73,6 +73,10 @@ func init() {
 		logging.Log.Error(err)
 		return
 	}
+
+	// Init groups then load commands that depend on groups
+	rootCmd.AddGroup(&groups.MonitoringGroup)
+	monitoring.RegisterMonitoringSubcommands(rootCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/verifyChartImages.go
+++ b/cmd/verifyChartImages.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/mallardduck/ob-charts-tool/internal/cmd/chartimages"
+	"github.com/mallardduck/ob-charts-tool/internal/logging"
 
 	"github.com/jedib0t/go-pretty/table"
 	"github.com/jedib0t/go-pretty/text"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -84,14 +84,14 @@ func verifyChartImagesHandler(_ *cobra.Command, args []string) {
 		} else {
 			helmArgs = fmt.Sprintf("template --debug rancher-monitoring %s -n cattle-monitoring-system", chartTargetRoot)
 		}
-		log.Debug(helmArgs)
+		logging.Log.Debug(helmArgs)
 		cmd := exec.Command("helm", strings.Split(helmArgs, " ")...)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 		err = cmd.Run()
 		if err != nil {
-			log.Error(stderr.String())
+			logging.Log.Error(stderr.String())
 			panic(err)
 		}
 

--- a/cmd/verifyChartImages.go
+++ b/cmd/verifyChartImages.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/mallardduck/ob-charts-tool/internal/cmd/chartimages"
-	"github.com/mallardduck/ob-charts-tool/internal/logging"
+	"github.com/rancher/ob-charts-tool/internal/cmd/chartimages"
+	"github.com/rancher/ob-charts-tool/internal/logging"
 
 	"github.com/jedib0t/go-pretty/table"
 	"github.com/jedib0t/go-pretty/text"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mallardduck/ob-charts-tool
+module github.com/rancher/ob-charts-tool
 
 go 1.23.6
 

--- a/internal/cmd/chartimages/main.go
+++ b/internal/cmd/chartimages/main.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/mallardduck/ob-charts-tool/internal/util"
+	"github.com/rancher/ob-charts-tool/internal/util"
 
 	"github.com/jedib0t/go-pretty/list"
 	log "github.com/sirupsen/logrus"

--- a/internal/cmd/rebaseinfo/main.go
+++ b/internal/cmd/rebaseinfo/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mallardduck/ob-charts-tool/internal/rebase"
-	"github.com/mallardduck/ob-charts-tool/internal/upstream"
+	"github.com/rancher/ob-charts-tool/internal/rebase"
+	"github.com/rancher/ob-charts-tool/internal/upstream"
 
 	"github.com/jedib0t/go-pretty/text"
 	log "github.com/sirupsen/logrus"

--- a/internal/git/main.go
+++ b/internal/git/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/mallardduck/ob-charts-tool/internal/util"
+	"github.com/rancher/ob-charts-tool/internal/util"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,62 @@
+package logging
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"os"
+)
+
+// Log is the global Logrus logger instance for the application.
+var Log *logrus.Logger
+
+func init() {
+	// Initialize the logger instance and its basic formatter/output
+	// This runs once when the package is imported.
+	Log = logrus.New()
+	Log.SetOutput(os.Stdout)
+	Log.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+		DisableColors: false, // Set to true if running in a non-color-enabled terminal
+	})
+	// Default level before configuration
+	Log.SetLevel(logrus.InfoLevel)
+}
+
+// Configure sets up the Logrus logger's level based on Viper's configuration
+// and the command's flags. It takes the *cobra.Command to inspect flag changes.
+func Configure(cmd *cobra.Command) {
+	// Viper reads the 'log-level' key, respecting the precedence order:
+	// flag > env var > config file > default
+	levelStr := viper.GetString("log-level")
+
+	level, err := logrus.ParseLevel(levelStr)
+	if err != nil {
+		Log.Warnf("Unknown log level '%s'. Defaulting to 'info'.", levelStr)
+		Log.SetLevel(logrus.InfoLevel)
+		return
+	}
+	Log.SetLevel(level)
+
+	// Determine the source of the log level for informational messages
+	source := getLogLevelSource(cmd)
+	Log.Debugf("Logrus level set to: %s (source: %s)", level.String(), source)
+}
+
+// getLogLevelSource determines whether the log level came from a flag,
+// environment variable, config file, or default.
+func getLogLevelSource(cmd *cobra.Command) string {
+	// Check if the log-level flag was explicitly set on the command line.
+	if flag := cmd.PersistentFlags().Lookup("log-level"); flag != nil && flag.Changed {
+		return "flag"
+	}
+	// Check if the environment variable was set.
+	if os.Getenv("OB_LOG_LEVEL") != "" { // Using the specific env var name
+		return "environment variable"
+	}
+	// Check if it came from the config file.
+	if viper.ConfigFileUsed() != "" && viper.IsSet("log-level") {
+		return "config file"
+	}
+	return "default"
+}

--- a/internal/rebase/chart.go
+++ b/internal/rebase/chart.go
@@ -6,11 +6,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/mallardduck/ob-charts-tool/internal/upstream"
-	"github.com/mallardduck/ob-charts-tool/internal/util"
+	"github.com/rancher/ob-charts-tool/internal/upstream"
+	"github.com/rancher/ob-charts-tool/internal/util"
 
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/mallardduck/ob-charts-tool/internal/git"
+	"github.com/rancher/ob-charts-tool/internal/git"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )

--- a/internal/rebase/main.go
+++ b/internal/rebase/main.go
@@ -3,7 +3,7 @@ package rebase
 import (
 	"fmt"
 
-	"github.com/mallardduck/ob-charts-tool/internal/util"
+	"github.com/rancher/ob-charts-tool/internal/util"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )

--- a/internal/rebase/types.go
+++ b/internal/rebase/types.go
@@ -1,6 +1,6 @@
 package rebase
 
-import "github.com/mallardduck/ob-charts-tool/internal/util"
+import "github.com/rancher/ob-charts-tool/internal/util"
 
 type ChartDep struct {
 	Name       string `yaml:"name"`

--- a/internal/upstream/main.go
+++ b/internal/upstream/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mallardduck/ob-charts-tool/internal/git"
+	"github.com/rancher/ob-charts-tool/internal/git"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/mallardduck/ob-charts-tool/cmd"
+	"github.com/rancher/ob-charts-tool/cmd"
 )
 
 func main() {


### PR DESCRIPTION
TL;DR: enables chart/project/domain specific commands to live under a group representing that entity.

So for monitoring specific commands we expect `monitoring:`. This has been implemented for `ob-charts-tool monitoring:getRebaseInfo` as that's specific to Monitoring and not logging.