### PR TITLE
Add ClusterRepo support to monitoring:testNewVersion

### DIFF
--- a/.github/workflows/setup-rancher-environment.yml
+++ b/.github/workflows/setup-rancher-environment.yml
@@ -12,6 +12,10 @@ on:
       chart_version:
         description: 'The target chart version to test (e.g., 107.2.0+up69.8.2-rancher.20)'
         required: true
+      cluster_repo:
+        description: 'The ClusterRepo to use (e.g., rancher-charts, ob-team-charts)'
+        required: false
+        default: 'rancher-charts'
 
 jobs:
   test-monitoring:
@@ -126,11 +130,35 @@ jobs:
           echo "token=$API_TOKEN" >> $GITHUB_OUTPUT
           echo "Successfully created and output Rancher API token."
 
+      - name: Create ob-team-charts ClusterRepo if needed
+        run: |
+          if [ "${{ github.event.inputs.cluster_repo }}" == "ob-team-charts" ]; then
+            # Check if the ClusterRepo already exists
+            if kubectl get clusterrepo ob-team-charts >/dev/null 2>&1; then
+              echo "ob-team-charts ClusterRepo already exists, skipping creation."
+            else
+              echo "Creating ob-team-charts ClusterRepo..."
+              kubectl apply -f - <<EOF
+          apiVersion: catalog.cattle.io/v1
+          kind: ClusterRepo
+          metadata:
+            name: ob-team-charts
+          spec:
+            gitBranch: main
+            gitRepo: https://github.com/rancher/ob-team-charts
+          EOF
+              echo "ob-team-charts ClusterRepo created."
+            fi
+          else
+            echo "Using ClusterRepo: ${{ github.event.inputs.cluster_repo }} (assuming it exists)"
+          fi
+
       - name: Test monitoring version
         run: |
-          echo "Waiting for rancher-charts clusterrepo to be downloaded..."
-          timeout 300s bash -c 'while [[ -z "$(kubectl get clusterrepo rancher-charts -o jsonpath='{.status.downloadTime}')" ]]; do echo -n "."; sleep 5; done'
-          echo "rancher-charts clusterrepo is ready."
+          echo "Waiting for ${{ github.event.inputs.cluster_repo }} clusterrepo to be downloaded..."
+          timeout 300s bash -c 'while [[ -z "$(kubectl get clusterrepo ${{ github.event.inputs.cluster_repo }} -o jsonpath='{.status.downloadTime}')" ]]; do echo -n "."; sleep 5; done'
+          echo "${{ github.event.inputs.cluster_repo }} clusterrepo is ready."
           ./ob-charts-tool monitoring:testNewVersion ${{ github.event.inputs.chart_version }} \
             --rancher-url ${{ steps.get-rancher-url.outputs.url }} \
-            --rancher-token ${{ steps.create-token.outputs.token }}
+            --rancher-token ${{ steps.create-token.outputs.token }} \
+            --cluster-repo ${{ github.event.inputs.cluster_repo }}

--- a/.github/workflows/setup-rancher-environment.yml
+++ b/.github/workflows/setup-rancher-environment.yml
@@ -15,7 +15,7 @@ on:
       cluster_repo:
         description: 'The ClusterRepo to use (e.g., rancher-charts, ob-team-charts)'
         required: false
-        default: 'rancher-charts'
+        default: 'ob-team-charts'
 
 jobs:
   test-monitoring:

--- a/cmd/monitoring/testNewVersion.go
+++ b/cmd/monitoring/testNewVersion.go
@@ -34,7 +34,7 @@ var testNewVersionCmd = &cobra.Command{
 func init() {
 	testNewVersionCmd.Flags().StringVar(&rancherURL, "rancher-url", "https://localhost:8443", "Rancher URL")
 	testNewVersionCmd.Flags().StringVar(&sessionToken, "rancher-token", "", "Rancher session token")
-	testNewVersionCmd.Flags().StringVar(&clusterRepo, "cluster-repo", "rancher-charts", "ClusterRepo to use")
+	testNewVersionCmd.Flags().StringVar(&clusterRepo, "cluster-repo", "ob-team-charts", "ClusterRepo to use")
 	testNewVersionCmd.MarkFlagRequired("rancher-token")
 }
 

--- a/cmd/monitoring/testNewVersion.go
+++ b/cmd/monitoring/testNewVersion.go
@@ -14,6 +14,7 @@ import (
 var (
 	rancherURL   string
 	sessionToken string
+	clusterRepo  string
 )
 
 // testNewVersionCmd represents the testNewVersion command
@@ -33,6 +34,7 @@ var testNewVersionCmd = &cobra.Command{
 func init() {
 	testNewVersionCmd.Flags().StringVar(&rancherURL, "rancher-url", "https://localhost:8443", "Rancher URL")
 	testNewVersionCmd.Flags().StringVar(&sessionToken, "rancher-token", "", "Rancher session token")
+	testNewVersionCmd.Flags().StringVar(&clusterRepo, "cluster-repo", "rancher-charts", "ClusterRepo to use")
 	testNewVersionCmd.MarkFlagRequired("rancher-token")
 }
 
@@ -41,7 +43,7 @@ func testNewMonitoringVersion(_ *cobra.Command, args []string) error {
 
 	// 1. Get previous version
 	fmt.Printf("Looking for version previous to %s...\n", newVersion)
-	previousVersion, err := monitoringTest.GetPreviousVersion(newVersion, rancherURL, sessionToken)
+	previousVersion, err := monitoringTest.GetPreviousVersion(newVersion, rancherURL, sessionToken, clusterRepo)
 	if err != nil {
 		return fmt.Errorf("error getting previous version: %w", err)
 	}
@@ -52,14 +54,14 @@ func testNewMonitoringVersion(_ *cobra.Command, args []string) error {
 
 	// 2. Test previous version
 	fmt.Printf("\n--- Testing Previous Version: %s ---\n", previousVersion)
-	previousVersionResults, err := testVersion(previousVersion, rancherURL, sessionToken)
+	previousVersionResults, err := testVersion(previousVersion, rancherURL, sessionToken, clusterRepo)
 	if err != nil {
 		return fmt.Errorf("failed to test version %s: %w", previousVersion, err)
 	}
 
 	// 3. Test new version
 	fmt.Printf("\n--- Testing New Version: %s ---\n", newVersion)
-	newVersionResults, err := testVersion(newVersion, rancherURL, sessionToken)
+	newVersionResults, err := testVersion(newVersion, rancherURL, sessionToken, clusterRepo)
 	if err != nil {
 		return fmt.Errorf("failed to test version %s: %w", newVersion, err)
 	}
@@ -70,10 +72,10 @@ func testNewMonitoringVersion(_ *cobra.Command, args []string) error {
 }
 
 // testVersion is a helper to install, test, and uninstall a specific chart version.
-func testVersion(version, rancherURL, sessionToken string) (map[string][]monitoringTest.PanelTestResult, error) {
+func testVersion(version, rancherURL, sessionToken, clusterRepo string) (map[string][]monitoringTest.PanelTestResult, error) {
 	// Install
 	fmt.Printf("Installing rancher-monitoring version %s...\n", version)
-	if err := monitoringTest.InstallCurrentVersion(version, rancherURL, sessionToken); err != nil {
+	if err := monitoringTest.InstallCurrentVersion(version, rancherURL, sessionToken, clusterRepo); err != nil {
 		return nil, fmt.Errorf("installation failed: %w", err)
 	}
 	fmt.Println("Installation complete. Waiting 1 minute for components to stabilize...")

--- a/internal/cmd/testnewmonitoringversion/testNewMonitoringVersion.go
+++ b/internal/cmd/testnewmonitoringversion/testNewMonitoringVersion.go
@@ -64,8 +64,8 @@ type Chart struct {
 }
 
 // GetPreviousVersion fetches the Helm index and finds the version prior to the one specified.
-func GetPreviousVersion(currentVersion, rancherURL, sessionToken string) (string, error) {
-	indexURL := fmt.Sprintf("%s/v1/catalog.cattle.io.clusterrepos/rancher-charts?link=index", rancherURL)
+func GetPreviousVersion(currentVersion, rancherURL, sessionToken, clusterRepo string) (string, error) {
+	indexURL := fmt.Sprintf("%s/v1/catalog.cattle.io.clusterrepos/%s?link=index", rancherURL, clusterRepo)
 
 	req, err := http.NewRequest("GET", indexURL, nil)
 	if err != nil {
@@ -131,8 +131,8 @@ func GetPreviousVersion(currentVersion, rancherURL, sessionToken string) (string
 }
 
 // InstallCurrentVersion installs the rancher-monitoring chart for a given version.
-func InstallCurrentVersion(chartVersion, rancherURL, sessionToken string) error {
-	url := fmt.Sprintf("%s/v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install", rancherURL)
+func InstallCurrentVersion(chartVersion, rancherURL, sessionToken, clusterRepo string) error {
+	url := fmt.Sprintf("%s/v1/catalog.cattle.io.clusterrepos/%s?action=install", rancherURL, clusterRepo)
 
 	payload := InstallPayload{
 		Charts: []Chart{
@@ -148,7 +148,7 @@ func InstallCurrentVersion(chartVersion, rancherURL, sessionToken string) error 
 				ChartName:   "rancher-monitoring",
 				Version:     chartVersion,
 				ReleaseName: "rancher-monitoring",
-				Annotations: map[string]string{"catalog.cattle.io/ui-source-repo-type": "cluster", "catalog.cattle.io/ui-source-repo": "rancher-charts"},
+				Annotations: map[string]string{"catalog.cattle.io/ui-source-repo-type": "cluster", "catalog.cattle.io/ui-source-repo": clusterRepo},
 				Values: map[string]interface{}{
 					"global":               map[string]interface{}{"cattle": map[string]interface{}{"systemDefaultRegistry": "", "clusterId": "local", "clusterName": "local", "url": rancherURL}},
 					"prometheus":           map[string]interface{}{"prometheusSpec": map[string]interface{}{"resources": map[string]interface{}{"requests": map[string]interface{}{"memory": "1750Mi"}}, "retentionSize": "50GiB"}},


### PR DESCRIPTION
This change is so that charts from the ob-team-charts repository can be tested by the tool and its GitHub workflow. See: rancher/rancher#54205

- Add a --cluster-repo flag to the monitoring:testNewVersion command
- Update GitHub workflow to support cluster_repo input
- Create the ob-team-charts ClusterRepo in the workflow if needed

The new flag has ob-team-charts as default, meaning the change is not backwards compatible. However, since the use of this tool is internal to our team and mostly via GHA, it shouldn't be a problem.