### PR TITLE
fix: Decontainerize setup-rancher-environment CI

### DIFF
--- a/.github/workflows/setup-rancher-environment.yml
+++ b/.github/workflows/setup-rancher-environment.yml
@@ -25,9 +25,7 @@ env:
 
 jobs:
   test-monitoring:
-    runs-on : ubuntu-latest
-    container:
-      image: ghcr.io/rancher/ci-image/go1.26
+    runs-on: ubuntu-latest
     outputs:
       rancher_token: ${{ steps.create-token.outputs.token }}
       rancher_url: ${{ steps.get-rancher-url.outputs.url }}
@@ -38,6 +36,11 @@ jobs:
 
       - name: Build workflow inputs summary
         run: bash -c ./scripts/ci-summary
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26'
 
       - name: Build ob-charts-tool
         run: go build -o ob-charts-tool main.go


### PR DESCRIPTION
As @alemorcuq pointed out, when we run this workflow in a containerized environment, the k3s installation process fails. The breakage started with commit 04ba00e7. We are currently decontainerizing this workflow until we can provide a better solution to the problem.